### PR TITLE
move derived constants out of config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The user running the web server process should be able to write to `UPLOADDIR`, 
 Directory | Mode | Owner:Group
 ----------|------|--------------
 `INSTALLDIR` | 755 | `programs:programs`
-`UPLOADDIR`  | 775 | `programs:www-data`
-`CONTENTDIR`  | 775 | `programs:www-data`
-`PROCESSDIR/logs` |775 | `programs:www-data`
+`INSTALLDIR/upload`  | 775 | `programs:www-data`
+`INSTALLDIR/content`  | 775 | `programs:www-data`
+`INSTALLDIR/process/logs` |775 | `programs:www-data`
 
 ### Sudo Permission Setup
 
@@ -68,17 +68,18 @@ replacing `[PROCESSDIR]` with the full path to the processing directory.
 ### Docker Setup
 
 Prepare the docker daemon by pulling the Chirun image on the server. For example, log into the server as the processing user and run the command:
-```
-$ docker pull chirun/chirun-docker:latest
+
+```bash
+docker pull coursebuilder/chirun-docker:latest
 ```
 
 ### Admin Directory Setup
 
 The web server's rewriting engine should be used to direct all requests of the form `lti/content/[...]` to `lti/index.php?req_content=[...]`. In addition, the following directories should be made forbidden for public access:
 
- * `UPLOADIR`
- * `PROCESSDIR`
- * `INSTALLDIR/lib`
+ * `WEBDIR/upload`
+ * `WEBDIR/process`
+ * `WEBDIR/lib`
 
 The path `WEBPATH/admin` should also be protected and allow only server administrator access. An example Apache setup using Basic Authentication is shown below.
 

--- a/config.dist.php
+++ b/config.dist.php
@@ -3,16 +3,13 @@
 // Application settings
 define('APP_NAME', 'Chirun LTI Tool');
 define('SESSION_NAME', 'php-chirun');
-define('VERSION', '0.2.0');
+define('VERSION', '0.2.1');
 
 // Setup paths
 define('WEBDIR', '/lti');
-define('WEBCONTENTDIR', WEBDIR.'/content');
 define('INSTALLDIR', '/var/www/webroot/lti');
-define('CONTENTDIR', INSTALLDIR.'/content');
-define('UPLOADDIR', INSTALLDIR.'/upload');
-define('PROCESSDIR', INSTALLDIR.'/process');
 define('PROCESSUSER', "programs");
+define('WEBUSER', "www-data");
 define('TEMPLATECACHE', "/tmp/cb_php/template_cache");
 
 // Database connection settings

--- a/lib/db.php
+++ b/lib/db.php
@@ -3,7 +3,7 @@
 use IMSGlobal\LTI\ToolProvider;
 use IMSGlobal\LTI\ToolProvider\DataConnector;
 
-require_once(__DIR__.'/../config.php');
+require_once(__DIR__.'/../settings.php');
 require_once(__DIR__.'/vendor/autoload.php');
 
 // Return a connection to the database, return FALSE if an error occurs

--- a/lib/init.php
+++ b/lib/init.php
@@ -6,7 +6,7 @@
 use IMSGlobal\LTI\ToolProvider;
 use IMSGlobal\LTI\ToolProvider\DataConnector;
 
-require_once(__DIR__.'/../config.php');
+require_once(__DIR__.'/../settings.php');
 require_once(__DIR__.'/db.php');
 require_once(__DIR__.'/resource.php');
 require_once(__DIR__.'/session.php');

--- a/process/process.sh
+++ b/process/process.sh
@@ -66,7 +66,7 @@ docker run --rm -v "${DOCKER_BIND}" -w ${PROCESS_TARGET} coursebuilder/chirun-do
 echo "Build successful. Copying output to LTI content directory..."
 rsync -a "build/" ${CONTENT_TARGET}
 cp config.yml ${CONTENT_TARGET}
-chown -R $(whoami):www-data ${CONTENT_TARGET}
+chown -R $(whoami):${WEBUSER} ${CONTENT_TARGET}
 chmod -R g+w ${CONTENT_TARGET}
 
 cleanup

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once(__DIR__ . '/config.php');
+
+// values derived from settings
+define('WEBCONTENTDIR', WEBDIR.'/content');
+define('CONTENTDIR', INSTALLDIR.'/content');
+define('UPLOADDIR', INSTALLDIR.'/upload');
+define('PROCESSDIR', INSTALLDIR.'/process');


### PR DESCRIPTION
settings.php defines WEBCONTENTDIR, CONTENTDIR, UPLOADDIR and PROCESSDIR
in terms of the configuration options. They shouldn't be anything else,
so they don't need to be in config.php.

This also adds a setting WEBUSER for the user running PHP, with default
`www-data`.