### PR TITLE
Add storage of title as name after compilation

### DIFF
--- a/material/admin.py
+++ b/material/admin.py
@@ -92,14 +92,15 @@ class LastLaunchedListFilter(admin.SimpleListFilter):
 
 
 class ChirunPackageAdmin(admin.ModelAdmin):
-    fieldsets = [(None,{"fields": ["title"]}),
+    fieldsets = [(None,{"fields": ["name"]}),
                  ("UIDs",{"fields": ["uid","edit_uid"]}),
                  ("Status",{"fields":["last_compiled","last_launched"]}),
                  ("Git Connection",{"fields": ["git_url","git_username","git_status"],"classes": ["collapse"]})]
-    list_display = ["title","uid","last_compiled","last_launched"] #("Status",{"list_display":["last_compiled"]})
+    list_display = ["name","uid","last_compiled","last_launched"] #("Status",{"list_display":["last_compiled"]})
     list_filter = [LastCompiledListFilter,LastLaunchedListFilter]
-    readonly_fields = ["title","last_compiled","last_launched"]
-    search_fields = ["uid","edit_uid","title"] #ZZZZ Searchable fields?
+    list_display_links = ["name","uid"]
+    readonly_fields = ["name","last_compiled","last_launched"]
+    search_fields = ["uid","edit_uid","name"]
 
     def get_queryset(self,request):
         #add the sorting conditions for the last compiled and last launched functions.

--- a/material/tasks.py
+++ b/material/tasks.py
@@ -76,7 +76,6 @@ async def do_build_package(compilation):
 
     with tempfile.TemporaryDirectory() as source_path, tempfile.TemporaryDirectory() as output_path:
         cache = get_cache()
-
         await compilation.send_status_change()
 
         channel_layer = get_channel_layer()
@@ -216,6 +215,8 @@ async def do_build_package(compilation):
         raise BuildException("There was an error during the build process.")
 
     compilation.status = 'built'
+    package.name = package.manifest.get('title')
+    await sync_to_async(package.save)(update_fields=['name'])
 
 @task()
 def delete_package_files(package):


### PR DESCRIPTION
Alters admin to use name rather than title, allowing searching and sorting This will result in a lot of empty 'name' fields until they are re-compiled, but the UID is now also a link within admin.

Related to #24 