### PR TITLE
Add context admin with linked packages, add git filter

### DIFF
--- a/lti/admin.py
+++ b/lti/admin.py
@@ -1,3 +1,30 @@
 from django.contrib import admin
 
+from material.models import PackageLTIUse
+from .models import Context, ResourceLink
+
 # Register your models here.
+
+class PackageLTIUseInline(admin.TabularInline):
+    model = PackageLTIUse
+    fields = ["package", "package_title"]
+    readonly_fields = ["package", "package_title"]
+    extra = 0
+    def package_title(self,instance):
+        return instance.package.name or instance.package.uid
+
+class ResourceLinkInline(admin.TabularInline):
+    model = ResourceLink
+    fields = ["title","tool","resource_link_id"]
+    readonly_fields = ["title","tool","resource_link_id"]
+    extra = 0
+
+class ContextAdmin(admin.ModelAdmin):
+    fieldsets = [(None,{"fields": ["title","tool","context_id"]})]
+    readonly_fields = ["title","tool","context_id"]
+
+    list_display = ["title","tool","context_id"] 
+    inlines = [PackageLTIUseInline,ResourceLinkInline]
+    
+
+admin.site.register(Context, ContextAdmin)


### PR DESCRIPTION
Adds an admin page for Contexts including linked packages. ChirunPackages now include their contexts in the individual admin pages under 'Package LTI uses'.

Adds a filter based on whether the git url is empty (assumed as an indicator of it not being git linked). If ChirunPackage is updated such that git_status contains 'Not linked', then this filter can be altered to use that and also filter based on error or similar.

Related to #24 