### PR TITLE
Orders null fields to 'last' in build/launch times

### DIFF
--- a/material/models.py
+++ b/material/models.py
@@ -112,7 +112,7 @@ class ChirunPackage(models.Model):
 
     @admin.display(description = "Last build",
                    boolean = False,
-                   ordering = "-last_compiled_sort")#[F('last_compiled_sort').desc(nulls_last=True)])#"-last_compiled_sort")
+                   ordering = F('last_compiled_sort').desc(nulls_last=True))
     def last_compiled(self):
         last_build = self.compilations.first()
         if last_build:
@@ -122,7 +122,7 @@ class ChirunPackage(models.Model):
         
     @admin.display(description = "Last launch",
                    boolean = False,
-                   ordering = "-last_launched_sort")
+                   ordering = F('last_launched_sort').desc(nulls_last=True))
     def last_launched(self):
         last_launch = self.launches.first()
         if last_launch:

--- a/material/models.py
+++ b/material/models.py
@@ -3,6 +3,7 @@ import configparser
 from   django.conf import settings
 from   django.contrib import admin
 from   django.db import models
+from   django.db.models import F
 from   django.urls import reverse
 from   django.utils.translation import gettext as _
 from   django.utils import timezone
@@ -111,7 +112,7 @@ class ChirunPackage(models.Model):
 
     @admin.display(description = "Last build",
                    boolean = False,
-                   ordering = "-last_compiled_sort")
+                   ordering = "-last_compiled_sort")#[F('last_compiled_sort').desc(nulls_last=True)])#"-last_compiled_sort")
     def last_compiled(self):
         last_build = self.compilations.first()
         if last_build:


### PR DESCRIPTION
Alters the ordering of Last Build and Last Launch such that nulls are ordered as the last item.

Resolves #34 