### PR TITLE
Add built status filter & column

### DIFF
--- a/material/models.py
+++ b/material/models.py
@@ -130,6 +130,16 @@ class ChirunPackage(models.Model):
         else:
             return 'Never Launched'
 
+    @admin.display(description = "Build status",
+                   boolean = False)
+    def build_status(self):
+        last_build = self.compilations.first()
+        if last_build:
+            #this should get the human-readable version of status, but doesn't. It might be something odd that the admin is doing.
+            return last_build.get_status_display()
+        else:
+            return _("Not built")
+
     def run_git_command(self, cmd, save_interaction=False):
         cmd = [str(x) for x in cmd]
         if save_interaction:


### PR DESCRIPTION
Resolves #35 

Adds a filter based on the status of the most recent compilation, and considers a package with no compilations 'not built'

Adds a column for this into the ChirunPackage admin and a line in each package's admin page.

A potential danger is that if a compilation has precisely the same start time as another package's 'latest' compilation, it will also be included - I expect as an extra row in the table, which may be misleading (although the build status column should still show the correct value, it will appear as part of an incorrect filter). This is due to the nature of querys and the way django talks with the database, it isn't actually able to directly get 'the last compilation's status' as part of a filter. This needs to be tested with a larger dataset to see how frequently it occurs - if it is common, we will likely need to switch to saving the last compilation status directly to the ChirunPackage model rather than only in each compilation.